### PR TITLE
Add solutions for first 2 kata

### DIFF
--- a/2023-03-15/century-from-year/simon.test.ts
+++ b/2023-03-15/century-from-year/simon.test.ts
@@ -1,0 +1,9 @@
+import { makeTest } from './test';
+
+//? Set to `true` when you are ready to enable tests
+const RUN_TESTS = true;
+makeTest(centuryFromYear, RUN_TESTS);
+
+export function centuryFromYear(year: number): number {
+  return Math.floor((year - 1) / 100) + 1;
+}

--- a/2023-03-15/lets-play-darts/simon.test.ts
+++ b/2023-03-15/lets-play-darts/simon.test.ts
@@ -1,0 +1,37 @@
+import { makeTest } from './test';
+
+//? Set to `true` when you are ready to enable tests
+const RUN_TESTS = true;
+makeTest(getDartboardScore, RUN_TESTS);
+
+const RADIUS = {
+  BULLS_EYE: 12.7 / 2,
+  BULL: 31.8 / 2,
+  TRIPPLE_INNER: 198 / 2,
+  TRIPPLE_OUTER: 214 / 2,
+  DOUBLE_INNER: 324 / 2,
+  DOUBLE_OUTER: 340 / 2,
+} as const;
+
+const SCORES = [
+  6, 13, 13, 4, 4, 18, 18, 1, 1, 20, 20, 5, 5, 12, 12, 9, 9, 14, 14, 11, 11, 8,
+  8, 16, 16, 7, 7, 19, 19, 3, 3, 17, 17, 2, 2, 15, 15, 10, 10, 6,
+];
+
+const SEGMENT_ANGLE = 360 / SCORES.length;
+
+function getDartboardScore(x: number, y: number) {
+  const distance = Math.sqrt(x * x + y * y);
+  if (distance >= RADIUS.DOUBLE_OUTER) return 'X';
+  if (distance <= RADIUS.BULLS_EYE) return 'DB';
+  if (distance <= RADIUS.BULL) return 'SB';
+  const angle = (Math.atan2(y, x) * 180) / Math.PI;
+  const segment = Math.floor(angle / SEGMENT_ANGLE);
+  const score = SCORES.at(segment);
+
+  if (distance <= RADIUS.TRIPPLE_OUTER && distance >= RADIUS.TRIPPLE_INNER)
+    return `T${score}`;
+  if (distance <= RADIUS.DOUBLE_OUTER && distance >= RADIUS.DOUBLE_INNER)
+    return `D${score}`;
+  return String(score);
+}

--- a/2023-03-15/string-repeat/simon.test.ts
+++ b/2023-03-15/string-repeat/simon.test.ts
@@ -1,0 +1,9 @@
+import { makeTest } from './test';
+
+//? Set to `true` when you are ready to enable tests
+const RUN_TESTS = true;
+makeTest(repeatStr, RUN_TESTS);
+
+export function repeatStr(n: number, s: string): string {
+  return s.repeat(n);
+}


### PR DESCRIPTION
# Kata

- [x] Problem 1
- [x] Problem 2
- [x] Problem 3

## Notes

My lets play darts solution is a bit hacky - I've divided each segment in half (40 total) to account for the fact that the axes intersect segments. I plan to adjust the calculation to remove this hack